### PR TITLE
Pass the query string from the page's location to the image URLs

### DIFF
--- a/ui/common.ts
+++ b/ui/common.ts
@@ -26,7 +26,7 @@ export const state: State = <State>{
 
 export var I18N = {};
 export var lang = navigator.language.toLocaleLowerCase();
-export var timestamp = new Date().getTime();
+export var timestamp = ((location.search || '?') + '&_=' + new Date().getTime()).substring(1);
 
 export function localize(str) {
     return (I18N[lang] && I18N[lang][str]) ? I18N[lang][str] : str;


### PR DESCRIPTION
For example, I have a link to the page in the code repository:

http://example.com/svn/Design/specification/export/index.html?revision=657213

On the page's content, there are links to images that have been added with the current timestamp:

```html
<div id="screen" class="screen" style="width: 442px; height: 489px; background: url(&quot;preview/page-1-1-red.png?1694705630858&quot;)..." ...>
```

After applying the fix, the same page:

```html
<div id="screen" class="screen" style="width: 442px; height: 489px; background: url(&quot;preview/page-1-1-red.png?revision=657213&_=1694705630858&quot;)..." ...>
```

The query string from the top location has been added to the image, ensuring that the version of the page and the version of the images are now synchronized.
